### PR TITLE
removed null attribute from ManyToMany field

### DIFF
--- a/status/models.py
+++ b/status/models.py
@@ -45,7 +45,7 @@ class Task(models.Model):
     assignees = models.ManyToManyField(User)
     due_date = models.DateField(default=date.today)
     team = models.ManyToManyField('members.Team', blank=True)
-    tags = models.ManyToManyField(TaskTag, blank=True, null=True)
+    tags = models.ManyToManyField(TaskTag, blank=True)
     status = models.ForeignKey(TaskStatus, on_delete=models.SET_NULL, null=True)
     updates = models.ManyToManyField(Status, blank=True)
 


### PR DESCRIPTION
Fixes: #3 
Removed `null` attribute from ManyToMany field in `Tasks model` in `status/models.py`.
null doesn't mean anything at the database level when used with a ManyToManyField.