### PR TITLE
status: Reverse the order

### DIFF
--- a/status/schema.py
+++ b/status/schema.py
@@ -30,4 +30,4 @@ class Query(graphene.ObjectType):
 
     def resolve_getMemberStatusUpdates(self, info, **kwargs):
         username = kwargs.get('username')
-        return Message.objects.values().filter(member__username=username)
+        return reversed(Message.objects.values().filter(member__username=username))


### PR DESCRIPTION
This commit is to reverse the order of members status updates to get the recent one first.